### PR TITLE
Introduce env config and minimal tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Telegram API credentials
+TELEGRAM_API_ID=your_api_id
+TELEGRAM_API_HASH=your_api_hash
+
+# Database
+DATABASE_URL=postgresql://telegram_user:password@localhost:5432/telegram_analysis
+
+# JWT and security
+JWT_SECRET=your_jwt_secret
+
+# Optional email alerts
+SMTP_SERVER=smtp.gmail.com
+SMTP_USERNAME=your_email@gmail.com
+SMTP_PASSWORD=your_app_password
+ALERT_EMAIL=admin@yourcompany.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+venv/
+.env
+# Node artifacts
+node_modules/
+# VSCode
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "backend_api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# TGF
+# Telegram Graph Framework
+
+This repository contains an experimental system for collecting and analyzing Telegram channel relations.
+For full documentation in Russian see [readme.md](readme.md).
+
+## Quick start
+
+1. Copy `.env.example` to `.env` and fill in your credentials.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the API:
+   ```bash
+   python backend_api.py
+   ```

--- a/backend_api.py
+++ b/backend_api.py
@@ -8,6 +8,7 @@ import asyncio
 import uvicorn
 from datetime import datetime, timedelta
 import logging
+import os
 
 # Модели данных
 class Channel(BaseModel):
@@ -223,7 +224,11 @@ class TemporalAnalyzer:
         return synchronized
 
 # Инициализация сервисов
-telegram_collector = TelegramDataCollector("fake_api_id", "fake_api_hash")
+# Читаем учетные данные из переменных окружения
+telegram_collector = TelegramDataCollector(
+    os.getenv("TELEGRAM_API_ID", ""),
+    os.getenv("TELEGRAM_API_HASH", "")
+)
 content_analyzer = ContentAnalyzer()
 network_analyzer = NetworkAnalyzer()
 temporal_analyzer = TemporalAnalyzer()

--- a/database_models.py
+++ b/database_models.py
@@ -5,9 +5,13 @@ from sqlalchemy.orm import sessionmaker, relationship
 from sqlalchemy.dialects.postgresql import UUID, ARRAY
 from datetime import datetime
 import uuid
+import os
 
 # Настройки подключения к базе данных
-DATABASE_URL = "postgresql://username:password@localhost/telegram_analysis"
+# Используем переменную окружения DATABASE_URL.
+# Значение по умолчанию подходит для локальной SQLite базы,
+# чтобы проект можно было запустить без дополнительной настройки.
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db.sqlite3")
 
 # Создание движка и сессии
 engine = create_engine(DATABASE_URL)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: telegram_analysis
+      POSTGRES_USER: telegram_user
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  api:
+    build: .
+    command: uvicorn backend_api:app --host 0.0.0.0 --port 8000
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+volumes:
+  db_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+sqlalchemy==2.0.23
+pydantic==2.5.0

--- a/telegram_collector.py
+++ b/telegram_collector.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Optional, Tuple
 from dataclasses import dataclass
 import aiofiles
 import aiohttp
+import os
 from PIL import Image
 import imagehash
 
@@ -463,8 +464,8 @@ class TelegramAnalyticsCollector:
 async def main():
     # Конфигурация
     config = TelegramConfig(
-        api_id="YOUR_API_ID",
-        api_hash="YOUR_API_HASH",
+        api_id=os.getenv("TELEGRAM_API_ID", ""),
+        api_hash=os.getenv("TELEGRAM_API_HASH", ""),
         session_name="analyzer_session"
     )
     

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from backend_api import app
+
+client = TestClient(app)
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "message" in response.json()


### PR DESCRIPTION
## Summary
- add gitignore and environment template
- load database url and telegram credentials from env
- add minimal Docker setup and requirements
- document quick start in README
- provide basic API test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e7c82fe1c8321b1d345191856dec9